### PR TITLE
Add Skapi photo sharing app

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Photo Gallery</title>
+    <script src="https://cdn.jsdelivr.net/npm/skapi-js@latest/dist/skapi.js"></script>
+    <script>
+        const skapi = new Skapi('ap22oqBfHOrr8X4OeFEc', 'f8e16604-69e4-451c-9d90-4410f801c006');
+        async function loadGallery(){
+            const profile = await skapi.getProfile();
+            if(!profile){
+                location.href = 'index.html';
+                return;
+            }
+            const userId = profile.user_id;
+            const res = await skapi.getRecords({ table: 'photos' });
+            const gallery = document.getElementById('gallery');
+            res.list.forEach(rec => {
+                const div = document.createElement('div');
+                div.className = 'gallery-item';
+                const img = document.createElement('img');
+                img.src = rec.bin.picture[0].url;
+                img.alt = rec.data?.description || '';
+                const p = document.createElement('p');
+                p.textContent = rec.data?.description || '';
+                div.appendChild(img);
+                div.appendChild(p);
+                if(rec.user_id === userId){
+                    const del = document.createElement('button');
+                    del.textContent = 'Delete';
+                    del.onclick = () => {
+                        skapi.deleteRecords({ record_id: rec.record_id }).then(() => location.reload());
+                    };
+                    div.appendChild(del);
+                }
+                gallery.appendChild(div);
+            });
+        }
+        window.addEventListener('DOMContentLoaded', loadGallery);
+    </script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Photo Gallery</h1>
+    <div id="gallery"></div>
+    <a href="index.html">Home</a>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Photo Share</title>
+    <script src="https://cdn.jsdelivr.net/npm/skapi-js@latest/dist/skapi.js"></script>
+    <script>
+        const skapi = new Skapi('ap22oqBfHOrr8X4OeFEc', 'f8e16604-69e4-451c-9d90-4410f801c006');
+        async function init() {
+            const profile = await skapi.getProfile();
+            const nav = document.getElementById('nav');
+            if (profile) {
+                nav.innerHTML = `
+                    <a href="upload.html">Upload Photo</a> |
+                    <a href="gallery.html">Photo Gallery</a> |
+                    <form onsubmit="skapi.logout(event)" action="index.html" style="display:inline;">
+                        <button type="submit">Logout</button>
+                    </form>
+                `;
+            } else {
+                nav.innerHTML = `
+                    <a href="signup.html">Sign Up</a> |
+                    <a href="login.html">Login</a>
+                `;
+            }
+        }
+        window.addEventListener('DOMContentLoaded', init);
+    </script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Welcome to Photo Share</h1>
+    <div id="nav"></div>
+</body>
+</html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <script src="https://cdn.jsdelivr.net/npm/skapi-js@latest/dist/skapi.js"></script>
+    <script>
+        const skapi = new Skapi('ap22oqBfHOrr8X4OeFEc', 'f8e16604-69e4-451c-9d90-4410f801c006');
+    </script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Login</h1>
+    <form action="index.html" onsubmit="skapi.login(event).catch(err => alert(err.message))">
+        <input name="email" type="email" placeholder="Email" required>
+        <input name="password" type="password" placeholder="Password" required>
+        <button type="submit">Login</button>
+    </form>
+    <a href="index.html">Back</a>
+</body>
+</html>

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Sign Up</title>
+    <script src="https://cdn.jsdelivr.net/npm/skapi-js@latest/dist/skapi.js"></script>
+    <script>
+        const skapi = new Skapi('ap22oqBfHOrr8X4OeFEc', 'f8e16604-69e4-451c-9d90-4410f801c006');
+    </script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Sign Up</h1>
+    <form action="login.html" onsubmit="skapi.signup(event).catch(err => alert(err.message))">
+        <input name="email" type="email" placeholder="Email" required>
+        <input name="password" type="password" placeholder="Password" required>
+        <input name="name" type="text" placeholder="Name" required>
+        <button type="submit">Sign Up</button>
+    </form>
+    <a href="index.html">Back</a>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,19 @@
+* { box-sizing: border-box; }
+body { font-family: Arial, sans-serif; margin: 20px; }
+input, button, progress {
+    display: block;
+    margin: 10px 0;
+    padding: 10px;
+    font-size: 1em;
+}
+a { margin-right: 10px; }
+img { max-width: 100%; height: auto; display: block; }
+.gallery-item {
+    margin-bottom: 20px;
+    border: 1px solid #ddd;
+    padding: 10px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+button { cursor: pointer; }
+progress { width: 100%; }

--- a/upload.html
+++ b/upload.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Upload Photo</title>
+    <script src="https://cdn.jsdelivr.net/npm/skapi-js@latest/dist/skapi.js"></script>
+    <script>
+        const skapi = new Skapi('ap22oqBfHOrr8X4OeFEc', 'f8e16604-69e4-451c-9d90-4410f801c006');
+        async function init(){
+            const profile = await skapi.getProfile();
+            if(!profile){
+                location.href = 'index.html';
+            }
+        }
+        function updateProgress(p){
+            const prog = document.getElementById('progress');
+            prog.style.display = 'block';
+            prog.value = p.progress;
+        }
+        window.addEventListener('DOMContentLoaded', init);
+    </script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Upload Photo</h1>
+    <form action="gallery.html" enctype="multipart/form-data" onsubmit="skapi.postRecord(event, { table: 'photos', progress: updateProgress }).catch(err => { alert(err.message); })">
+        <input name="description" placeholder="Description" required>
+        <input type="file" name="picture" accept="image/*" required>
+        <button type="submit">Upload</button>
+        <progress id="progress" value="0" max="100" style="display:none;"></progress>
+    </form>
+    <a href="index.html">Home</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build index page with login-aware navigation
- add sign up and login forms
- restrict upload and gallery pages to logged-in users
- upload photos with descriptions to `photos` table
- list all uploaded photos with delete option
- add simple material-style CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68641431dd2483268c7ed87cd4935634